### PR TITLE
fix: call XInitThreads first

### DIFF
--- a/lib/daemon.go
+++ b/lib/daemon.go
@@ -107,9 +107,12 @@ func (d *Daemon) AddNote(args *NoteArgs, reply *VoidReply) error {
 }
 
 func (d *Daemon) Run(stop chan bool) {
-	x11 := NewX11()
+	x11, err := NewX11()
+	if err != nil {
+		log.Panic(err)
+	}
 	if err := x11.Init(); err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	rpc.Register(d)

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -1,5 +1,7 @@
 package lib
 
+import "fmt"
+
 type TimerIsAlreadyStarted struct{}
 
 func (e *TimerIsAlreadyStarted) Error() string {
@@ -24,8 +26,10 @@ func (e *TimerIsNotSuspended) Error() string {
 	return "The timer is not suspended."
 }
 
-type X11Error struct{}
+type X11Error struct {
+	Code int
+}
 
 func (e *X11Error) Error() string {
-	return "X11 call failed."
+	return fmt.Sprintf("X11 call failed (%v)", e.Code)
 }

--- a/lib/x11.go
+++ b/lib/x11.go
@@ -12,15 +12,19 @@ type X11 struct {
 	Display *C.Display
 }
 
-func NewX11() X11 {
+func NewX11() (X11, error) {
+	if errno := C.XInitThreads(); errno == 0 {
+		return X11{}, &X11Error{Code: int(errno)}
+	}
+
 	return X11{
 		Display: C.XOpenDisplay(C.CString("")),
-	}
+	}, nil
 }
 
 func (x *X11) Init() error {
 	if errno := C.init(x.Display); errno != C.Success {
-		return &X11Error{}
+		return &X11Error{Code: int(errno)}
 	}
 
 	return nil
@@ -29,7 +33,7 @@ func (x *X11) Init() error {
 func (x *X11) GetIdleTime() (time.Duration, error) {
 	var idleMs C.int64_t
 	if ok := C.getIdleMs(x.Display, &idleMs); ok == 0 {
-		return 0, &X11Error{}
+		return 0, &X11Error{Code: 0}
 	}
 
 	return time.Duration(idleMs * 1e6), nil


### PR DESCRIPTION
Seems like concurrent access to X11 can cause issues when `XInitThreads` hasn't been called first. I suspect this causes #2 . I'm running this patched version on my machine now and we'll see if that fixes the issue.